### PR TITLE
Prevent bombardment of calls to `audioElement.play()`

### DIFF
--- a/src/components/Controls.js
+++ b/src/components/Controls.js
@@ -70,8 +70,13 @@ const Controles = () => {
   // Post-Render On-Change settings
   useEffect(() => {
     const audioElement = getAudioElement();
+    
+    if (playing && audioElement.paused)  {
+      audioElement.play();
+    } else if (!playing && !audioElement.paused) { 
+      audioElement.pause();
+    }
 
-    playing ? audioElement.play() : audioElement.pause();
     gainNode.gain.value = volume;
     panner.pan.value = pan;
   }, [playing, volume, pan]); // Run only when these values change


### PR DESCRIPTION
Noticed some audio popping when I moved the pan and gain bars. It seems that `audioElement.play()` was being called with every update. Filtering when we call `audioElement.play()` seems to stop the popping.

